### PR TITLE
instead of directly opening the socket connection, ITransportConnectionFactory returns a TransportConnection object

### DIFF
--- a/SINFONI/Context.cs
+++ b/SINFONI/Context.cs
@@ -107,7 +107,8 @@ namespace SINFONI
             }
             catch (Exception e)
             {
-                Console.WriteLine("Failed to open Socket connection to ws://{0}:{1}, Reason: {2} ", host, port, e.Message);
+                Console.WriteLine("Failed to open connection of type {0} to host {1} on port {2}. Reason: {3}",
+                    transportName, host, port, e.Message);
             }
         }
 

--- a/SINFONI/Context.cs
+++ b/SINFONI/Context.cs
@@ -90,7 +90,7 @@ namespace SINFONI
                 .GetTransport(transportName)
                 .TransportConnectionFactory;
             IProtocol protocol = protocolRegistry.GetProtocol(protocolName);
-            ITransportConnection transportConnection = transportConnectionFactory.OpenConnection(host, port, this, onConnected);
+            ITransportConnection transportConnection = transportConnectionFactory.CreateTransportConnection(host, port, this);
             transportConnection.Error += (sender, e) =>
             {
                 Console.WriteLine("An error occured while connection to host " + host + ":" + port + ": " + e.Exception);
@@ -101,6 +101,14 @@ namespace SINFONI
                 establishedConnection.LoadIDL(ServerConfiguration);
                 onConnected(establishedConnection);
             };
+            try
+            {
+                transportConnection.Open();
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("Failed to open Socket connection to ws://{0}:{1}, Reason: {2} ", host, port, e.Message);
+            }
         }
 
         private void GetHostAndPortFromUrl(string url, out string host, out int port)

--- a/SINFONI/Transport/ITransportConnectionFactory.cs
+++ b/SINFONI/Transport/ITransportConnectionFactory.cs
@@ -26,14 +26,13 @@ namespace SINFONI
     public interface ITransportConnectionFactory
     {
         /// <summary>
-        /// Opens a connection to the remote server and executes <paramref name="onConnected"/> when the connection
-        /// is established.
+        /// Creates a TransportConnection object which event handlers can be assigned to. That object can then be used
+        /// to open the connection to the remote server.
         /// </summary>
         /// <param name="host">IP Address or hostname of the server</param>
         /// <param name="port">Port under which remote server is listening</param>
         /// <param name="context">Context under which the connection is openend</param>
-        /// <param name="onConnected">Callback to be called when the connection is established.</param>
-        ITransportConnection OpenConnection(string host, int port, Context context, Action<Connection> onConnected);
+        ITransportConnection CreateTransportConnection(string host, int port, Context context);
 
         /// <summary>
         /// Starts the server listening for new clients

--- a/Transports/WebSocket/WebSocketConnectionFactory.cs
+++ b/Transports/WebSocket/WebSocketConnectionFactory.cs
@@ -31,7 +31,7 @@ namespace SINFONI.Transport.WebSocketTransport
     {
         #region IConnectionFactory implementation
 
-        public ITransportConnection OpenConnection(string host, int port, Context context, Action<Connection> onConnected)
+        public ITransportConnection CreateTransportConnection(string host, int port, Context context)
         {
             if (port == -1 || host == null)
                 throw new Error(ErrorCode.CONNECTION_ERROR, "No port and/or IP address is present in configuration.");
@@ -41,14 +41,7 @@ namespace SINFONI.Transport.WebSocketTransport
             {
                 Console.WriteLine("Error in connection to " + host + ":" + port + ":   " + e.Exception.Message);
             };
-            try
-            {
-                transportConnection.Open();
-            }
-            catch(Exception e)
-            {
-                Console.WriteLine("Failed to open Socket connection to ws://{0}:{1}, Reason: {2} ", host, port, e.Message);
-            }
+
             return transportConnection;
         }
 


### PR DESCRIPTION
The connection will now be opened by the Context after the event handlers are assigned.
Also removes an unused callback function argument